### PR TITLE
gha: fix upload build path and image logo

### DIFF
--- a/templates/.github/workflows/ci.yml
+++ b/templates/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           uses: actions/upload-artifact@v1
           with:
             name: build-artifact-${{ matrix.env }}
-            path: build/
+            path: public/
         ## This sets `step.outputs` is picked up by `jobs.outputs`, then when the step deploy reads `jobs.outputs`
         ## this provides data and set matrix for the deploy steps. This allows us to specify the data once
         ## and have the subsequence step can pass along the information created during this step.

--- a/templates/gatsby-config.js
+++ b/templates/gatsby-config.js
@@ -33,7 +33,7 @@ module.exports = {
         background_color: `#663399`,
         theme_color: `#663399`,
         display: `minimal-ui`,
-        icon: `src/images/gatsby-icon.png`, // This path is relative to the root of the site.
+        icon: `src/images/logo.png`, // This path is relative to the root of the site.
       },
     },
     // this (optional) plugin enables Progressive Web App + Offline functionality


### PR DESCRIPTION
`yarn build` builds to `/public` rather than `build` 

landing page comes with a plugin that compresses images (previously was gatsby logo, but now should be logo.png)


